### PR TITLE
fix: gpu requirements

### DIFF
--- a/gpu_requirements.txt
+++ b/gpu_requirements.txt
@@ -1,5 +1,6 @@
+--extra-index-url https://download.pytorch.org/whl/cu116
+torch==1.12.1
 docarray
 jina>=3.0
 Pillow==9.0.1
-torch==1.10.2
 transformers==4.16.2


### PR DESCRIPTION
GPU version doesn't work: 

```
from jina import Flow
from docarray import Document, DocumentArray
import numpy as np

f = Flow().add(uses='jinahub+docker://CLIPEncoder/latest-gpu/', uses_with = {'device': 'cuda'}, gpus='all')

docs = DocumentArray(
        [
            Document(tensor=np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8))
            for _ in range(50)
        ] + [
            Document(text='just some random text here') for _ in range(50)]) 

if __name__ == '__main__' :

    with f as flow:
        da = flow.post(on='/index', inputs=docs)
```
because of CUDA errors

CUDA error: no kernel image is available for execution on the device\nCUDA kernel errors might be asynchronously reported at some other API call,so the stacktrace below might be incorrect.\nFor debugging consider passing CUDA_LAUNCH_BLOCKING=1