### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 docarray
 jina>=3.0
 Pillow==9.0.1
-torch==1.10.2+cpu
+torch==1.12.0
 transformers==4.16.2


### PR DESCRIPTION
We should upgrade the torch version since the version 1.10.2+cpu is not available anymore. Otherwise when installing the dependencies from jinahub, it would fail.